### PR TITLE
Algorithms perf phase 1: vectorize gen_patterns + perf bench harness

### DIFF
--- a/server/patterns.py
+++ b/server/patterns.py
@@ -231,18 +231,22 @@ def gen_patterns(papdata: Dict[str, Any], start_time: datetime, duration: int = 
         # meaningful 0-1 movement probability from raw visitor counts.
         peak_busyness = _compute_peak_busyness(stats)
 
-        # People state
-        # At any time, a person is either at home or at a place with a 'leave_time' scheduled.
-        # (We don't model inter-POI hopping here; that could be added by sampling again after leaving.)
-        people_state: Dict[int, Dict[str, Any]] = {}
-        for sid, info in papdata.get("people", {}).items():
-            pid = int(sid)
-            people_state[pid] = {
-                "home": str(info.get("home")),
-                "at_place": False,
-                "place_id": None,
-                "leave_time_idx": None,  # hour index when they will leave the place
-            }
+        # People state held in parallel arrays so the mover-decision hot loop
+        # can run as a batched numpy op instead of one rng.random + rng.choice
+        # + rng.integers call per person. is_home_arr is the source of truth
+        # for whether each person is at home or out; leave_time_arr holds the
+        # hour at which they'll return; dest_place_id_arr holds the destination
+        # place_id (only meaningful when at place).
+        people = list(papdata.get("people", {}).items())
+        n_people = len(people)
+        pid_str_list: List[str] = [None] * n_people  # str(int(sid))
+        home_str_list: List[str] = [None] * n_people  # str(info["home"])
+        for i, (sid, info) in enumerate(people):
+            pid_str_list[i] = str(int(sid))
+            home_str_list[i] = str(info.get("home"))
+        is_home_arr = np.ones(n_people, dtype=bool)
+        leave_time_arr = np.full(n_people, -1, dtype=np.int64)
+        dest_place_id_arr: List[Any] = [None] * n_people
 
     output: Dict[str, Any] = {}
 
@@ -253,14 +257,15 @@ def gen_patterns(papdata: Dict[str, Any], start_time: datetime, duration: int = 
         weekday = WEEKDAYS[current_time.weekday()]
         hour_of_day = current_time.hour
 
-        # People who need to leave now (normal dwell time expiry)
+        # People whose dwell time expires this hour return home.
         with _timed("gen_patterns/leave_time_expiry"):
-            for pid, st in people_state.items():
-                if st["at_place"] and st["leave_time_idx"] == hour_idx:
-                    # send home
-                    st["at_place"] = False
-                    st["place_id"] = None
-                    st["leave_time_idx"] = None
+            expired_mask = (leave_time_arr == hour_idx)
+            if expired_mask.any():
+                is_home_arr[expired_mask] = True
+                leave_time_arr[expired_mask] = -1
+                # dest_place_id_arr entries are not cleared on return; they
+                # are only read when is_home_arr[i] is False, so stale values
+                # are unreachable.
 
         # Build intensity distribution for this hour (normalized — for destination selection)
         with _timed("gen_patterns/intensity_distribution"):
@@ -283,40 +288,64 @@ def gen_patterns(papdata: Dict[str, Any], start_time: datetime, duration: int = 
 
             base_move_prob = min(0.35, 0.85 * overall_busy)
 
-        # Decide moves for each person at home
+        # Vectorized mover decision: batch the rng draws across all people at
+        # home this hour, then apply assignments only to those who actually
+        # move. RNG draw ORDER differs from the original per-person loop, so
+        # outputs are NOT byte-identical to the pre-vectorization code; the
+        # statistical distribution is preserved (each person has the same
+        # base_move_prob; destinations are still drawn with place_probs;
+        # dwell still triangular around median-1..median+1).
         with _timed("gen_patterns/mover_decision"):
-            for pid, st in people_state.items():
-                if st["at_place"]:
-                    continue  # already out
+            home_indices = np.where(is_home_arr)[0]
+            n_home = int(home_indices.size)
+            n_places = len(place_ids)
+            if n_home > 0 and n_places > 0:
+                move_rolls = rng.random(n_home)
+                movers_mask = move_rolls < base_move_prob
+                n_movers = int(movers_mask.sum())
+                if n_movers > 0:
+                    mover_indices = home_indices[movers_mask]
+                    dest_choice_idx = rng.choice(n_places, size=n_movers, p=place_probs)
+                    dest_choice_list = dest_choice_idx.tolist()
+                    dest_place_ids_for_movers = [place_ids[c] for c in dest_choice_list]
+                    median_per_mover = np.fromiter(
+                        (stats[pid]["median_dwell_hours"] for pid in dest_place_ids_for_movers),
+                        dtype=np.int64,
+                        count=n_movers,
+                    )
+                    lo = np.maximum(1, median_per_mover - 1)
+                    hi_inclusive = median_per_mover + 1
+                    dwell_hours_arr = rng.integers(lo, hi_inclusive + 1)
+                    new_leave_time = np.minimum(duration, hour_idx + dwell_hours_arr)
 
-                if len(place_ids) == 0:
-                    continue  # nothing open/busy for this hour
-
-                if rng.random() < base_move_prob:
-                    # pick a destination
-                    choice_idx = int(rng.choice(len(place_ids), p=place_probs))
-                    dest_place_id = place_ids[choice_idx]
-
-                    # dwell time from median_dwell
-                    median_hours = stats[dest_place_id]["median_dwell_hours"]
-                    # add a little noise around the median (triangular around [median-1, median+1])
-                    lo = max(1, median_hours - 1)
-                    hi = median_hours + 1
-                    dwell_hours = int(rng.integers(lo, hi + 1))
-
-                    st["at_place"] = True
-                    st["place_id"] = dest_place_id
-                    st["leave_time_idx"] = min(duration, hour_idx + dwell_hours)
+                    is_home_arr[mover_indices] = False
+                    leave_time_arr[mover_indices] = new_leave_time
+                    for arr_idx, place_id in zip(mover_indices.tolist(), dest_place_ids_for_movers):
+                        dest_place_id_arr[arr_idx] = place_id
 
         # Snapshot at the end of this hour
         with _timed("gen_patterns/snapshot_assembly"):
             homes_map: Dict[str, List[str]] = {}
             places_map: Dict[str, List[str]] = {}
-            for pid, st in people_state.items():
-                if st["at_place"] and st["place_id"] is not None:
-                    places_map.setdefault(str(st["place_id"]), []).append(str(pid))
+            # tolist() up front turns 50k numpy bool indexing into 50k local
+            # truthiness checks, which is measurably faster in CPython.
+            is_home_list = is_home_arr.tolist()
+            for i in range(n_people):
+                pid_str = pid_str_list[i]
+                if is_home_list[i]:
+                    home_id = home_str_list[i]
+                    bucket = homes_map.get(home_id)
+                    if bucket is None:
+                        homes_map[home_id] = [pid_str]
+                    else:
+                        bucket.append(pid_str)
                 else:
-                    homes_map.setdefault(str(st["home"]), []).append(str(pid))
+                    place_id = str(dest_place_id_arr[i])
+                    bucket = places_map.get(place_id)
+                    if bucket is None:
+                        places_map[place_id] = [pid_str]
+                    else:
+                        bucket.append(pid_str)
 
             # Key is minutes from start_time. hour_idx=0 processes the first hour (0:00-1:00),
             # so we store at minute 60 to represent the state AT hour 1.

--- a/server/patterns.py
+++ b/server/patterns.py
@@ -1,15 +1,24 @@
 
 import ast
+import contextlib
 import csv
 import json
+import logging
 import math
 import numpy as np
 import pandas as pd
 import os
+import time
 from datetime import datetime, timedelta
 from typing import Dict, Any, List, Tuple, Optional
 
 WEEKDAYS = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+
+_PATTERNS_LOGGER = logging.getLogger(__name__)
+
+
+def _perf_timings_enabled() -> bool:
+    return os.getenv("DELINEO_PERF_TIMINGS", "").lower() in {"1", "true", "yes", "on"}
 
 
 def _parse_hour_list(val) -> List[int]:
@@ -188,37 +197,52 @@ def gen_patterns(papdata: Dict[str, Any], start_time: datetime, duration: int = 
     Output format matches the original: a dict keyed by cumulative minutes,
     each mapping to {"homes": {home_id: [person_ids]}, "places": {place_id: [person_ids]}}.
     """
-    # Map placekey -> pap place_id
-    placekey_to_place_id: Dict[str, str] = {}
-    for pid, desc in papdata.get("places", {}).items():
-        pk = desc.get("placekey")
-        if pk:
-            placekey_to_place_id[pk] = pid
+    perf_accum: Dict[str, float] = {}
+    perf_on = _perf_timings_enabled()
 
-    # Derive stats from the shared PatternsData. If none/empty, stats is empty.
-    if shared_data is not None and not shared_data.is_empty():
-        placekey_set = set(placekey_to_place_id.keys())
-        stats_df = shared_data.for_patterns_stats(placekey_set)
-        stats = _build_stats_from_df(stats_df, placekey_to_place_id)
-    else:
-        stats = {}
+    @contextlib.contextmanager
+    def _timed(label: str):
+        if not perf_on:
+            yield
+            return
+        started = time.perf_counter()
+        try:
+            yield
+        finally:
+            perf_accum[label] = perf_accum.get(label, 0.0) + (time.perf_counter() - started)
 
-    # Pre-compute peak busyness across the entire week so we can derive a
-    # meaningful 0-1 movement probability from raw visitor counts.
-    peak_busyness = _compute_peak_busyness(stats)
+    with _timed("gen_patterns/setup_stats"):
+        # Map placekey -> pap place_id
+        placekey_to_place_id: Dict[str, str] = {}
+        for pid, desc in papdata.get("places", {}).items():
+            pk = desc.get("placekey")
+            if pk:
+                placekey_to_place_id[pk] = pid
 
-    # People state
-    # At any time, a person is either at home or at a place with a 'leave_time' scheduled.
-    # (We don't model inter-POI hopping here; that could be added by sampling again after leaving.)
-    people_state: Dict[int, Dict[str, Any]] = {}
-    for sid, info in papdata.get("people", {}).items():
-        pid = int(sid)
-        people_state[pid] = {
-            "home": str(info.get("home")),
-            "at_place": False,
-            "place_id": None,
-            "leave_time_idx": None,  # hour index when they will leave the place
-        }
+        # Derive stats from the shared PatternsData. If none/empty, stats is empty.
+        if shared_data is not None and not shared_data.is_empty():
+            placekey_set = set(placekey_to_place_id.keys())
+            stats_df = shared_data.for_patterns_stats(placekey_set)
+            stats = _build_stats_from_df(stats_df, placekey_to_place_id)
+        else:
+            stats = {}
+
+        # Pre-compute peak busyness across the entire week so we can derive a
+        # meaningful 0-1 movement probability from raw visitor counts.
+        peak_busyness = _compute_peak_busyness(stats)
+
+        # People state
+        # At any time, a person is either at home or at a place with a 'leave_time' scheduled.
+        # (We don't model inter-POI hopping here; that could be added by sampling again after leaving.)
+        people_state: Dict[int, Dict[str, Any]] = {}
+        for sid, info in papdata.get("people", {}).items():
+            pid = int(sid)
+            people_state[pid] = {
+                "home": str(info.get("home")),
+                "at_place": False,
+                "place_id": None,
+                "leave_time_idx": None,  # hour index when they will leave the place
+            }
 
     output: Dict[str, Any] = {}
 
@@ -230,70 +254,81 @@ def gen_patterns(papdata: Dict[str, Any], start_time: datetime, duration: int = 
         hour_of_day = current_time.hour
 
         # People who need to leave now (normal dwell time expiry)
-        for pid, st in people_state.items():
-            if st["at_place"] and st["leave_time_idx"] == hour_idx:
-                # send home
-                st["at_place"] = False
-                st["place_id"] = None
-                st["leave_time_idx"] = None
+        with _timed("gen_patterns/leave_time_expiry"):
+            for pid, st in people_state.items():
+                if st["at_place"] and st["leave_time_idx"] == hour_idx:
+                    # send home
+                    st["at_place"] = False
+                    st["place_id"] = None
+                    st["leave_time_idx"] = None
 
         # Build intensity distribution for this hour (normalized — for destination selection)
-        place_ids, raw_weights = _overall_busy_factor(stats, weekday, hour_of_day)
-        if raw_weights:
-            place_probs = np.array(raw_weights, dtype=float)
-            place_probs = place_probs / place_probs.sum()
-        else:
-            place_probs = np.array([])
+        with _timed("gen_patterns/intensity_distribution"):
+            place_ids, raw_weights = _overall_busy_factor(stats, weekday, hour_of_day)
+            if raw_weights:
+                place_probs = np.array(raw_weights, dtype=float)
+                place_probs = place_probs / place_probs.sum()
+            else:
+                place_probs = np.array([])
 
         # Compute movement probability from raw visitor counts.
         # overall_busy is a 0-1 ratio: current aggregate activity / peak activity
         # across the whole week. This properly captures "how busy is right now"
         # using absolute magnitudes rather than the normalized distribution.
-        if peak_busyness > 0:
-            overall_busy = _aggregate_busyness(stats, weekday, hour_of_day) / peak_busyness
-        else:
-            overall_busy = 0.0
+        with _timed("gen_patterns/aggregate_busyness"):
+            if peak_busyness > 0:
+                overall_busy = _aggregate_busyness(stats, weekday, hour_of_day) / peak_busyness
+            else:
+                overall_busy = 0.0
 
-        base_move_prob = min(0.35, 0.85 * overall_busy)
+            base_move_prob = min(0.35, 0.85 * overall_busy)
 
         # Decide moves for each person at home
-        for pid, st in people_state.items():
-            if st["at_place"]:
-                continue  # already out
+        with _timed("gen_patterns/mover_decision"):
+            for pid, st in people_state.items():
+                if st["at_place"]:
+                    continue  # already out
 
-            if len(place_ids) == 0:
-                continue  # nothing open/busy for this hour
+                if len(place_ids) == 0:
+                    continue  # nothing open/busy for this hour
 
-            if rng.random() < base_move_prob:
-                # pick a destination
-                choice_idx = int(rng.choice(len(place_ids), p=place_probs))
-                dest_place_id = place_ids[choice_idx]
+                if rng.random() < base_move_prob:
+                    # pick a destination
+                    choice_idx = int(rng.choice(len(place_ids), p=place_probs))
+                    dest_place_id = place_ids[choice_idx]
 
-                # dwell time from median_dwell
-                median_hours = stats[dest_place_id]["median_dwell_hours"]
-                # add a little noise around the median (triangular around [median-1, median+1])
-                lo = max(1, median_hours - 1)
-                hi = median_hours + 1
-                dwell_hours = int(rng.integers(lo, hi + 1))
+                    # dwell time from median_dwell
+                    median_hours = stats[dest_place_id]["median_dwell_hours"]
+                    # add a little noise around the median (triangular around [median-1, median+1])
+                    lo = max(1, median_hours - 1)
+                    hi = median_hours + 1
+                    dwell_hours = int(rng.integers(lo, hi + 1))
 
-                st["at_place"] = True
-                st["place_id"] = dest_place_id
-                st["leave_time_idx"] = min(duration, hour_idx + dwell_hours)
+                    st["at_place"] = True
+                    st["place_id"] = dest_place_id
+                    st["leave_time_idx"] = min(duration, hour_idx + dwell_hours)
 
         # Snapshot at the end of this hour
-        homes_map: Dict[str, List[str]] = {}
-        places_map: Dict[str, List[str]] = {}
-        for pid, st in people_state.items():
-            if st["at_place"] and st["place_id"] is not None:
-                places_map.setdefault(str(st["place_id"]), []).append(str(pid))
-            else:
-                homes_map.setdefault(str(st["home"]), []).append(str(pid))
+        with _timed("gen_patterns/snapshot_assembly"):
+            homes_map: Dict[str, List[str]] = {}
+            places_map: Dict[str, List[str]] = {}
+            for pid, st in people_state.items():
+                if st["at_place"] and st["place_id"] is not None:
+                    places_map.setdefault(str(st["place_id"]), []).append(str(pid))
+                else:
+                    homes_map.setdefault(str(st["home"]), []).append(str(pid))
 
-        # Key is minutes from start_time. hour_idx=0 processes the first hour (0:00-1:00),
-        # so we store at minute 60 to represent the state AT hour 1.
-        # Frontend interprets key "60" as "1 hour from start" which is correct.
-        current_minutes = (hour_idx + 1) * 60
-        output[str(current_minutes)] = {"homes": homes_map, "places": places_map}
+            # Key is minutes from start_time. hour_idx=0 processes the first hour (0:00-1:00),
+            # so we store at minute 60 to represent the state AT hour 1.
+            # Frontend interprets key "60" as "1 hour from start" which is correct.
+            current_minutes = (hour_idx + 1) * 60
+            output[str(current_minutes)] = {"homes": homes_map, "places": places_map}
+
+    if perf_on:
+        # Emit via print so the line is visible even when the algorithms logger
+        # configuration is changed by callers.
+        for label in sorted(perf_accum):
+            print(f"[perf] {label}: {perf_accum[label]:.3f}s", flush=True)
 
     return output
 

--- a/server/popgen.py
+++ b/server/popgen.py
@@ -748,6 +748,15 @@ def convert_data(df, cz_data, shared_data=None):
 
     return output
 
+def _apply_bench_seed():
+    seed = os.getenv('DELINEO_BENCH_SEED')
+    if seed is None or seed == '':
+        return
+    seed_int = int(seed)
+    random.seed(seed_int)
+    np.random.seed(seed_int)
+
+
 def gen_pop(cz_data, gdf=None, shared_data=None):
     """
     Generate synthetic population for a convenience zone.
@@ -760,6 +769,8 @@ def gen_pop(cz_data, gdf=None, shared_data=None):
     Returns:
         Dictionary with people, homes, and places data (papdata format)
     """
+    _apply_bench_seed()
+
     # Create data puller
     datapuller = CensusDataPuller()
 

--- a/server/residential.py
+++ b/server/residential.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import random
 from typing import Dict, List, Optional, Sequence, Tuple, Union
 
@@ -123,7 +124,8 @@ class ResidentialCache:
 
     def __init__(self, gdf, use_buildings: bool = True):
         self.use_buildings = bool(use_buildings)
-        self._rng = random.Random()
+        bench_seed = os.getenv('DELINEO_BENCH_SEED')
+        self._rng = random.Random(int(bench_seed)) if bench_seed else random.Random()
 
         self.cbg_gdf = self._normalize_cbg_gdf(gdf)
         self.metric_crs = self._pick_metric_crs(self.cbg_gdf)
@@ -238,15 +240,17 @@ class ResidentialCache:
                 west=min_lng,
                 tags=tags,
             )
-        except Exception:
+        except Exception as exc:
             LOGGER.warning(
-                "ResidentialCache: failed to fetch OSM features for bbox %.6f,%.6f,%.6f,%.6f",
+                "ResidentialCache: failed to fetch OSM features for bbox %.6f,%.6f,%.6f,%.6f (%s: %s); using fallback",
                 min_lng,
                 min_lat,
                 max_lng,
                 max_lat,
-                exc_info=True,
+                type(exc).__name__,
+                exc,
             )
+            LOGGER.debug("OSM fetch traceback:", exc_info=True)
             return self._empty_geodataframe()
 
         if features is None or len(features) == 0:

--- a/server/scripts/perf_benchmark.README.md
+++ b/server/scripts/perf_benchmark.README.md
@@ -1,0 +1,56 @@
+# Perf benchmark harness
+
+End-to-end timing harness for the Delineo pipeline:
+`generate_cz` -> `gen_pop` -> `gen_patterns` -> simulation -> `processSimulation`.
+
+Used for the `ryad/perf-phase1` work. Drives all three repos in-process from
+their `perf-phase1` worktrees (Algorithms, Simulation, Fullstack), records
+per-stage timings, hashes of intermediate artifacts, and peak RSS, then writes
+a structured `summary.json`.
+
+## Usage
+
+```
+/opt/anaconda3/envs/delineo_env/bin/python perf_benchmark.py \
+  2>&1 | tee <output_root>/full.log
+```
+
+Defaults: ZIP 74002, `mobility_prune` at `min_seed_capture=0.70`, `min_pop=5000`,
+168h, start 2021-04-01, `DELINEO_BENCH_SEED=0`, 1 smoke + 3 measured.
+
+## Environment variables
+
+Set automatically by the harness (you can override):
+- `DELINEO_PERF_TIMINGS=1` — turns on `[perf]` stage logs in all three repos.
+- `DELINEO_BENCH_SEED=0` — deterministic seed for `gen_pop` and `ResidentialCache`.
+
+Set these to point at non-default paths:
+- `DELINEO_ROOT` — parent dir holding the Delineo sibling repos.
+- `DELINEO_ALGORITHMS_WORKTREE`, `DELINEO_SIMULATION_WORKTREE`,
+  `DELINEO_FULLSTACK_WORKTREE` — perf worktree paths.
+- `DELINEO_ALGORITHMS_DATA_CWD` — directory the Algorithms code runs from
+  (where `data/...` is resolved).
+- `DELINEO_PATTERNS_FILE` — SafeGraph patterns parquet for the target month.
+- `DELINEO_NODE_PROCESSOR` — path to `process_simulation.js`.
+- `DELINEO_FULLSTACK_NODE_MODULES` — path to Fullstack's `node_modules`.
+- `DELINEO_PERF_RUNS` — output directory (default: `$DELINEO_ROOT/_perf-runs`).
+
+## CLI flags
+
+- `--measured-runs N` (default 3)
+- `--hours N` (default 168)
+- `--min-pop N` (default 5000)
+- `--min-seed-capture F` (default 0.70)
+- `--start-date YYYY-MM-DD` (default 2021-04-01)
+- `--bench-seed S` (default `"0"`; pass empty string to disable seeding)
+- `--skip-smoke`
+- `--output-root PATH`
+
+## Output
+
+- `<output_root>/<NN>-<label>/` — per-run artifacts (papdata, simdata,
+  movement, map-cache).
+- `<output_root>/summary.json` — `{env, args, runs[]}`. `runs[].hashes`
+  include content hashes for `.gz` files (gunzipped) so gzip-header noise
+  doesn't show as drift.
+- `<output_root>/full.log` — full stdout of the last harness run.

--- a/server/scripts/perf_benchmark.README.md
+++ b/server/scripts/perf_benchmark.README.md
@@ -11,9 +11,16 @@ a structured `summary.json`.
 ## Usage
 
 ```
-/opt/anaconda3/envs/delineo_env/bin/python perf_benchmark.py \
+caffeinate -i -s /opt/anaconda3/envs/delineo_env/bin/python perf_benchmark.py \
   2>&1 | tee <output_root>/full.log
 ```
+
+`caffeinate -i -s` is required on macOS — without it the system may idle-sleep
+during a long run. `time.perf_counter()` and Node's `process.hrtime.bigint()`
+behave differently across sleep on macOS, which produces nonsensical sub-stage
+timings (e.g. one run reported `simulation total: 225s` but the simdata file
+was written ~27 minutes after gen_patterns finished). With `caffeinate` the
+machine stays awake and timings are physical wall-clock.
 
 Defaults: ZIP 74002, `mobility_prune` at `min_seed_capture=0.70`, `min_pop=5000`,
 168h, start 2021-04-01, `DELINEO_BENCH_SEED=0`, 1 smoke + 3 measured.

--- a/server/scripts/perf_benchmark.py
+++ b/server/scripts/perf_benchmark.py
@@ -1,0 +1,414 @@
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import json
+import logging
+import os
+import platform
+import resource
+import shutil
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+# Paths can be overridden via env vars so this script is portable across machines.
+# Defaults match the parent directory holding the Delineo sibling repos and the
+# `ryad/perf-phase1` worktrees under `_worktrees/`.
+ROOT = Path(os.environ.get("DELINEO_ROOT", "/Users/ryad/Code/delineo"))
+ALGORITHMS_WORKTREE = Path(
+    os.environ.get("DELINEO_ALGORITHMS_WORKTREE", ROOT / "_worktrees" / "algorithms-perf-phase1")
+)
+SIMULATION_WORKTREE = Path(
+    os.environ.get("DELINEO_SIMULATION_WORKTREE", ROOT / "_worktrees" / "simulation-perf-phase1")
+)
+FULLSTACK_WORKTREE = Path(
+    os.environ.get("DELINEO_FULLSTACK_WORKTREE", ROOT / "_worktrees" / "fullstack-perf-phase1")
+)
+ALGORITHMS_DATA_CWD = Path(
+    os.environ.get("DELINEO_ALGORITHMS_DATA_CWD", ROOT / "Algorithms" / "server")
+)
+PATTERNS_FILE = Path(
+    os.environ.get(
+        "DELINEO_PATTERNS_FILE",
+        ROOT
+        / "Algorithms"
+        / "server"
+        / "data"
+        / "gdrive_1qtMYMT0sHQ7IYojSstbYtqUyTGJNukk1"
+        / "data"
+        / "patterns"
+        / "OK"
+        / "2021-04-OK.parquet",
+    )
+)
+NODE_PROCESSOR = Path(
+    os.environ.get(
+        "DELINEO_NODE_PROCESSOR",
+        Path(__file__).resolve().parent / "process_simulation.js",
+    )
+)
+
+ZIP_CODE = "74002"
+SEED_CBGS = ["401139400081", "401139400082", "401139400083"]
+START_DATE = datetime(2021, 4, 1)
+DEFAULT_HOURS = 168
+DEFAULT_MIN_POP = 5000
+DEFAULT_MIN_SEED_CAPTURE = 0.70
+
+
+def configure_imports() -> None:
+    sys.path.insert(0, str(SIMULATION_WORKTREE))
+    sys.path.insert(0, str(ALGORITHMS_WORKTREE / "server"))
+    os.chdir(ALGORITHMS_DATA_CWD)
+
+
+def _git_head(repo: Path) -> str:
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(repo), "rev-parse", "HEAD"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def _node_version() -> str:
+    try:
+        out = subprocess.run(
+            ["node", "--version"],
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+        )
+        return out.stdout.strip()
+    except Exception:
+        return "unknown"
+
+
+def collect_env_metadata() -> dict[str, Any]:
+    return {
+        "python_version": sys.version.split()[0],
+        "python_executable": sys.executable,
+        "node_version": _node_version(),
+        "uname": platform.platform(),
+        "git_head": {
+            "algorithms": _git_head(ALGORITHMS_WORKTREE),
+            "simulation": _git_head(SIMULATION_WORKTREE),
+            "fullstack": _git_head(FULLSTACK_WORKTREE),
+        },
+    }
+
+
+def _maxrss_mb() -> float:
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return rss / 1024.0 / 1024.0 if sys.platform == "darwin" else rss / 1024.0
+
+
+def stable_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def file_hash(path: Path) -> str:
+    digest = hashlib.sha256()
+    is_gzip = path.suffix == ".gz"
+    opener = gzip.open if is_gzip else open
+    with opener(path, "rb") as f:
+        for chunk in iter(lambda: f.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def timed(label: str, func):
+    started_at = time.perf_counter()
+    result = func()
+    elapsed = time.perf_counter() - started_at
+    print(f"[perf] {label}: {elapsed:.3f}s", flush=True)
+    return result, elapsed
+
+
+def write_gzip_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with gzip.open(path, "wt", encoding="utf-8") as f:
+        json.dump(value, f, separators=(",", ":"))
+
+
+def run_node_processor(
+    run_dir: Path,
+    simdata_path: Path,
+    movement_path: Path,
+    papdata_id: str,
+    length_minutes: int,
+    run_number: int,
+) -> tuple[Path, float]:
+    map_cache_path = run_dir / "map-cache.json"
+    env = os.environ.copy()
+    env["DB_FOLDER"] = str(run_dir / "db") + "/"
+    env["DELINEO_PERF_TIMINGS"] = "1"
+    env["NODE_PATH"] = str(ROOT / "Fullstack" / "node_modules")
+
+    started_at = time.perf_counter()
+    completed = subprocess.run(
+        [
+            "node",
+            str(NODE_PROCESSOR),
+            "--simdata",
+            str(simdata_path),
+            "--patterns",
+            str(movement_path),
+            "--papdata-id",
+            papdata_id,
+            "--map-cache",
+            str(map_cache_path),
+            "--length",
+            str(length_minutes),
+            "--sim-data-id",
+            str(run_number),
+        ],
+        cwd=str(FULLSTACK_WORKTREE),
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        check=True,
+    )
+    elapsed = time.perf_counter() - started_at
+    print(completed.stdout, end="", flush=True)
+    print(f"[perf] processSimulation subprocess total: {elapsed:.3f}s", flush=True)
+    return map_cache_path, elapsed
+
+
+def run_once(label: str, index: int, output_root: Path, args) -> dict[str, Any]:
+    from czcode import generate_cz
+    from patterns import gen_patterns
+    from patterns_loader import PatternsData
+    from popgen import gen_pop
+    from simulator.runner import SimulationRunner
+
+    run_dir = output_root / f"{index:02d}-{label}"
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True)
+
+    print(
+        f"[bench] run={label} zip={ZIP_CODE} algorithm=mobility_prune "
+        f"min_seed_capture={args.min_seed_capture:.2f} min_pop={args.min_pop} "
+        f"start={args.start_date} hours={args.hours} bench_seed={os.environ.get('DELINEO_BENCH_SEED', '')}",
+        flush=True,
+    )
+
+    rss_before_mb = _maxrss_mb()
+
+    geoids_result, generate_cz_seconds = timed(
+        "generate_cz",
+        lambda: generate_cz(
+            SEED_CBGS[0],
+            args.min_pop,
+            patterns_file=str(PATTERNS_FILE),
+            start_date=START_DATE,
+            algorithm="mobility_prune",
+            seed_cbgs=SEED_CBGS,
+            mobility_prune_min_seed_capture=args.min_seed_capture,
+        ),
+    )
+    geoids, _map_obj, gdf = geoids_result
+    cbg_set = set(geoids.keys())
+
+    shared_data, patterns_load_seconds = timed(
+        "patterns load",
+        lambda: PatternsData.load([str(PATTERNS_FILE)], cbg_set=cbg_set),
+    )
+    papdata, gen_pop_seconds = timed(
+        "gen_pop",
+        lambda: gen_pop(geoids, gdf=gdf, shared_data=shared_data),
+    )
+    patterns, gen_patterns_seconds = timed(
+        "gen_patterns",
+        lambda: gen_patterns(papdata, START_DATE, args.hours, shared_data=shared_data),
+    )
+
+    papdata_id = "papdata"
+    write_gzip_json(run_dir / "db" / f"{papdata_id}.gz", papdata)
+
+    length_minutes = args.hours * 60
+    simdata = {
+        "czone_id": index,
+        "length": length_minutes,
+        "randseed": False,
+        "initial_infected_count": 1,
+        "disease_name": "COVID-19",
+        "variants": ["Delta"],
+        "dmp_mode": "off",
+        "model_path_by_variant": {"Delta": None},
+        "interventions": [
+            {
+                "time": 0,
+                "mask": 0.4,
+                "vaccine": 0.2,
+                "capacity": 1.0,
+                "lockdown": 0.0,
+                "selfiso": 0.5,
+            }
+        ],
+    }
+
+    def data_loader(_url, timeout=360):
+        return papdata, patterns
+
+    simulation_output_dir = run_dir / "simulation-output"
+    simulator_logger = logging.getLogger("simulator.runner")
+    previous_simulator_log_level = simulator_logger.level
+    simulator_logger.setLevel(logging.WARNING)
+    try:
+        simulation_result, simulation_seconds = timed(
+            "simulation total",
+            lambda: SimulationRunner(
+                simdata,
+                enable_logging=False,
+                output_dir=str(simulation_output_dir),
+                data_loader=data_loader,
+            ).run(),
+        )
+    finally:
+        simulator_logger.setLevel(previous_simulator_log_level)
+    if "error" in simulation_result:
+        raise RuntimeError(f"Simulation failed: {simulation_result['error']}")
+
+    simdata_path = Path(simulation_result["simdata"])
+    movement_path = Path(simulation_result["patterns"])
+    map_cache_path, process_seconds = run_node_processor(
+        run_dir,
+        simdata_path,
+        movement_path,
+        papdata_id,
+        length_minutes,
+        index,
+    )
+
+    rss_after_mb = _maxrss_mb()
+    result = {
+        "label": label,
+        "index": index,
+        "zip": ZIP_CODE,
+        "seed_cbgs": SEED_CBGS,
+        "algorithm": "mobility_prune",
+        "min_seed_capture": args.min_seed_capture,
+        "min_pop": args.min_pop,
+        "bench_seed": os.environ.get("DELINEO_BENCH_SEED", ""),
+        "start_date": args.start_date,
+        "hours": args.hours,
+        "length_minutes": length_minutes,
+        "cbg_count": len(geoids),
+        "population": int(sum(geoids.values())),
+        "people_count": len(papdata.get("people", {})),
+        "home_count": len(papdata.get("homes", {})),
+        "place_count": len(papdata.get("places", {})),
+        "pattern_timesteps": len(patterns),
+        "rss_mb": {
+            "before": rss_before_mb,
+            "after": rss_after_mb,
+            "delta": rss_after_mb - rss_before_mb,
+        },
+        "timings": {
+            "generate_cz": generate_cz_seconds,
+            "patterns_load": patterns_load_seconds,
+            "gen_pop": gen_pop_seconds,
+            "gen_patterns": gen_patterns_seconds,
+            "simulation": simulation_seconds,
+            "process_simulation": process_seconds,
+        },
+        "hashes": {
+            "geoids": stable_hash(geoids),
+            "papdata": stable_hash(papdata),
+            "patterns": stable_hash(patterns),
+            "simdata_file": file_hash(simdata_path),
+            "movement_file": file_hash(movement_path),
+            "map_cache_file": file_hash(map_cache_path),
+        },
+        "artifacts": {
+            "run_dir": str(run_dir),
+            "simdata": str(simdata_path),
+            "movement": str(movement_path),
+            "map_cache": str(map_cache_path),
+        },
+    }
+    print("[bench-result] " + json.dumps(result, sort_keys=True), flush=True)
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--measured-runs", type=int, default=3)
+    parser.add_argument(
+        "--output-root",
+        default=os.environ.get("DELINEO_PERF_RUNS", str(ROOT / "_perf-runs")),
+    )
+    parser.add_argument("--hours", type=int, default=DEFAULT_HOURS)
+    parser.add_argument("--min-pop", type=int, default=DEFAULT_MIN_POP)
+    parser.add_argument("--min-seed-capture", type=float, default=DEFAULT_MIN_SEED_CAPTURE)
+    parser.add_argument("--start-date", default=START_DATE.date().isoformat())
+    parser.add_argument("--skip-smoke", action="store_true")
+    parser.add_argument("--bench-seed", default="0",
+                        help="Value for DELINEO_BENCH_SEED; pass empty string to disable.")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+    os.environ["DELINEO_PERF_TIMINGS"] = "1"
+    if args.bench_seed:
+        os.environ["DELINEO_BENCH_SEED"] = args.bench_seed
+    else:
+        os.environ.pop("DELINEO_BENCH_SEED", None)
+
+    configure_imports()
+    if not PATTERNS_FILE.exists():
+        raise FileNotFoundError(PATTERNS_FILE)
+    if not NODE_PROCESSOR.exists():
+        raise FileNotFoundError(NODE_PROCESSOR)
+
+    output_root = Path(args.output_root)
+    output_root.mkdir(parents=True, exist_ok=True)
+
+    env_metadata = collect_env_metadata()
+    print(f"[bench-env] {json.dumps(env_metadata, sort_keys=True)}", flush=True)
+
+    results = []
+    run_index = 0
+    if not args.skip_smoke:
+        results.append(run_once("smoke", run_index, output_root, args))
+        run_index += 1
+
+    for measured_index in range(args.measured_runs):
+        results.append(run_once(f"measured-{measured_index + 1}", run_index, output_root, args))
+        run_index += 1
+
+    summary = {
+        "env": env_metadata,
+        "args": {
+            "measured_runs": args.measured_runs,
+            "hours": args.hours,
+            "min_pop": args.min_pop,
+            "min_seed_capture": args.min_seed_capture,
+            "start_date": args.start_date,
+            "bench_seed": args.bench_seed,
+            "skip_smoke": args.skip_smoke,
+        },
+        "runs": results,
+    }
+    summary_path = output_root / "summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True), encoding="utf-8")
+    print(f"[bench-summary] {summary_path}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/server/scripts/process_simulation.js
+++ b/server/scripts/process_simulation.js
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const Module = require('module');
+const path = require('path');
+
+// Path defaults match the parent directory holding the Delineo sibling repos.
+// Override DELINEO_ROOT or DELINEO_FULLSTACK_WORKTREE for other machines.
+const root = process.env.DELINEO_ROOT || '/Users/ryad/Code/delineo';
+const fullstackWorktree = process.env.DELINEO_FULLSTACK_WORKTREE
+  || path.join(root, '_worktrees', 'fullstack-perf-phase1');
+const fullstackNodeModules = process.env.DELINEO_FULLSTACK_NODE_MODULES
+  || path.join(root, 'Fullstack', 'node_modules');
+process.env.NODE_PATH = [
+  fullstackNodeModules,
+  process.env.NODE_PATH || ''
+].filter(Boolean).join(path.delimiter);
+Module._initPaths();
+
+const ts = require('typescript');
+
+require.extensions['.ts'] = function loadTs(module, filename) {
+  const source = fs.readFileSync(filename, 'utf8');
+  const output = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
+      skipLibCheck: true
+    },
+    fileName: filename
+  }).outputText;
+  module._compile(output, filename);
+};
+
+function readArgs(argv) {
+  const args = {};
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i];
+    const value = argv[i + 1];
+    if (!key || !key.startsWith('--') || value === undefined) {
+      throw new Error(`Invalid argument list near ${key || '<end>'}`);
+    }
+    args[key.slice(2)] = value;
+  }
+  return args;
+}
+
+async function main() {
+  const args = readArgs(process.argv);
+  const { processSimulation } = require(path.join(
+    fullstackWorktree,
+    'src',
+    'lib',
+    'sim-processor.ts'
+  ));
+
+  await processSimulation({
+    simDataId: Number(args['sim-data-id'] || 1),
+    simdataPath: args.simdata,
+    patternsPath: args.patterns,
+    papdataId: args['papdata-id'],
+    mapCachePath: args['map-cache'],
+    totalLength: Number(args.length)
+  });
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/server/server_app/generation_service.py
+++ b/server/server_app/generation_service.py
@@ -1,5 +1,7 @@
 import json
+import os
 import threading
+import time
 from datetime import datetime
 
 import geopandas as gpd
@@ -11,6 +13,15 @@ from patterns_loader import PatternsData, resolve_patterns_files, states_from_cb
 from popgen import gen_pop
 
 
+def _perf_timings_enabled():
+    return os.getenv('DELINEO_PERF_TIMINGS', '').lower() in {'1', 'true', 'yes', 'on'}
+
+
+def _report_perf_timing(report, label, started_at):
+    if _perf_timings_enabled():
+        report.info(f'[perf] {label}: {time.perf_counter() - started_at:.3f}s')
+
+
 class ConvenienceZoneGenerationService:
     def __init__(self, fullstack_client, generation_store):
         self.fullstack_client = fullstack_client
@@ -19,10 +30,12 @@ class ConvenienceZoneGenerationService:
     def gen_and_upload_data(self, geoids, czone_id, start_date, length, report, gdf=None,
                             patterns_file=None):
         try:
+            total_start = time.perf_counter()
             self.generation_store.update(czone_id, 'Loading patterns data...', 5)
             shared_data = None
             cbg_set = set(geoids.keys())
 
+            stage_start = time.perf_counter()
             if patterns_file:
                 shared_data = PatternsData.load([patterns_file], cbg_set=cbg_set)
             else:
@@ -32,13 +45,16 @@ class ConvenienceZoneGenerationService:
                     if resolved_files:
                         report.info(f'Auto-resolved patterns files: {resolved_files}')
                         shared_data = PatternsData.load(resolved_files, cbg_set=cbg_set)
+            _report_perf_timing(report, 'patterns load', stage_start)
 
             report.info(f'Patterns data loaded: {len(shared_data.df) if shared_data else 0} rows')
             self.generation_store.update(czone_id, 'Patterns data loaded', 20)
 
             report.info('Generating synthetic population (papdata)...')
             self.generation_store.update(czone_id, 'Generating synthetic population...', 25)
+            stage_start = time.perf_counter()
             papdata = gen_pop(geoids, gdf=gdf, shared_data=shared_data)
+            _report_perf_timing(report, 'gen_pop', stage_start)
             people_count = len(papdata.get('people', {}))
             homes_count = len(papdata.get('homes', {}))
             places_count = len(papdata.get('places', {}))
@@ -53,12 +69,14 @@ class ConvenienceZoneGenerationService:
 
             report.info('Generating movement patterns...')
             self.generation_store.update(czone_id, 'Generating movement patterns...', 50)
+            stage_start = time.perf_counter()
             patterns = gen_patterns(
                 papdata,
                 start_date,
                 length,
                 shared_data=shared_data
             )
+            _report_perf_timing(report, 'gen_patterns', stage_start)
             patterns_count = len(patterns)
             report.info(f'Generated {patterns_count} timestep patterns')
             self.generation_store.update(czone_id, f'Generated {patterns_count} movement patterns', 75)
@@ -68,6 +86,7 @@ class ConvenienceZoneGenerationService:
             report.info('Uploading data to DB API...')
             self.generation_store.update(czone_id, 'Uploading data...', 80)
             resp = self.fullstack_client.upload_patterns(czone_id, papdata, patterns)
+            _report_perf_timing(report, 'cz data generation total', total_start)
 
             if resp.ok:
                 report.info('Data uploaded successfully!')
@@ -87,6 +106,7 @@ class ConvenienceZoneGenerationService:
             self.generation_store.update(czone_id, f'Error: {str(exc)}', 0, error=True)
 
     def create_cz(self, data, report, pattern_selection, algorithm_config):
+        total_start = time.perf_counter()
         report.info(f"Generating CZ from CBG: {data['cbg']}")
         report.info(f"Target minimum population: {data['min_pop']}")
 
@@ -127,6 +147,7 @@ class ConvenienceZoneGenerationService:
             max_satellites=algorithm_config['effective_hierarchical_params'].get('max_satellites'),
             mobility_prune_min_seed_capture=algorithm_config['effective_mobility_prune_params'].get('min_seed_capture'),
         )
+        _report_perf_timing(report, 'generate_cz', total_start)
 
         cluster = list(geoids.keys())
         size = sum(list(geoids.values()))


### PR DESCRIPTION
## Summary
Six commits rebased onto current main. Surprisingly clean — the `algorithms-refactor` that landed on main (PR #12) split `clustering.py` and related modules into the `czcode_modules/` package, but perf-phase1 only touches `patterns.py`, `popgen.py`, `residential.py`, and `generation_service.py` (all stable across the refactor), so no textual conflicts.

**Runtime perf**
- **Vectorize `gen_patterns`** — mover decision and parallel-array state. Replaces per-person Python loops with numpy array ops in the hot path.

**Reproducibility / observability (opt-in)**
- **`DELINEO_PERF_TIMINGS=1`** — stage timings for CZ generation in `generation_service.py`.
- **`DELINEO_BENCH_SEED`** — stabilizes `gen_pop` output so bench runs are comparable.
- **`gen_patterns` inner-loop sub-timers** — under the same env var.

**Benchmark harness**
- New `server/scripts/perf_benchmark.py` — interleaved 4-cycle bench driver.
- `server/scripts/perf_benchmark.README.md` — usage + `caffeinate` note for macOS.
- `server/scripts/process_simulation.js` — small helper used by the harness.

## Test plan
- [x] `pytest tests/algorithms_server/` — 25/25 pass
- [x] `python -m py_compile` clean on all touched files
- [x] Manual smoke: full dev stack running on rebased branch (port 1880), CZ generator route flow tested on perf-phase1 (rebased diff vs that is zero, since cherry-pick produced identical trees)
- [ ] Re-run the 4-cycle perf bench after merge

## Files changed
```
server/patterns.py                      | 238 +++---
server/popgen.py                        |  11 ++
server/residential.py                   |  12 +-
server/scripts/perf_benchmark.README.md |  63 +++ (new)
server/scripts/perf_benchmark.py        | 414 +++ (new)
server/scripts/process_simulation.js    |  70 +++ (new)
server/server_app/generation_service.py |  21 ++
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)