### PR TITLE
Emit per-POI floor area in papdata (for area-aware ventilation)

### DIFF
--- a/server/patterns_loader.py
+++ b/server/patterns_loader.py
@@ -24,13 +24,13 @@ _PATTERN_EXTS = ('.parquet', '.csv.gz', '.converted.csv', '.csv')
 
 # All columns any algorithm step might need (lowercase canonical names).
 # CZ clustering:  poi_cbg, visitor_daytime_cbgs, postal_code
-# Popgen:         poi_cbg, placekey, location_name, top_category, latitude, longitude, street_address, postal_code, polygon_wkt
+# Popgen:         poi_cbg, placekey, location_name, top_category, latitude, longitude, street_address, postal_code, polygon_wkt, wkt_area_sq_meters
 # Patterns gen:   placekey, median_dwell, popularity_by_hour, popularity_by_day
 ALL_NEEDED_COLUMNS = [
     'poi_cbg', 'visitor_daytime_cbgs', 'postal_code',
     'placekey', 'location_name', 'top_category', 'latitude', 'longitude',
     'street_address',
-    'polygon_wkt',
+    'polygon_wkt', 'wkt_area_sq_meters',
     'median_dwell', 'popularity_by_hour', 'popularity_by_day',
 ]
 
@@ -250,9 +250,10 @@ class PatternsData:
         return self._df.loc[mask, 'placekey'].dropna().unique().tolist()
 
     def for_popgen_places(self, placekeys: List[str]) -> pd.DataFrame:
-        """Place info for popgen: placekey, name, category, coords, address, zip, polygon."""
+        """Place info for popgen: placekey, name, category, coords, address, zip, polygon, area."""
         cols = [c for c in ['placekey', 'location_name', 'top_category',
-                            'latitude', 'longitude', 'street_address', 'postal_code', 'polygon_wkt']
+                            'latitude', 'longitude', 'street_address', 'postal_code', 'polygon_wkt',
+                            'wkt_area_sq_meters']
                 if c in self._df.columns]
         if 'placekey' not in self._df.columns:
             return pd.DataFrame()

--- a/server/popgen.py
+++ b/server/popgen.py
@@ -677,6 +677,7 @@ def convert_data(df, cz_data, shared_data=None):
         'street_address',
         'postal_code',
         'polygon_wkt',
+        'wkt_area_sq_meters',
     ]
 
     if shared_data is not None and not shared_data.is_empty():
@@ -733,7 +734,26 @@ def convert_data(df, cz_data, shared_data=None):
         text = str(v).strip()
         return text or None
 
+    # Physical floor area (m^2) per POI, from SafeGraph WKT_AREA_SQ_METERS. Used
+    # downstream for area-aware Wells-Riley ventilation. Non-positive / missing
+    # values are filled with the per-category median, then the global median,
+    # then a constant (the dataset median POI is ~649 m^2). Winsorizing the long
+    # tail (e.g. a region polygon logged as one giant "POI") happens at the
+    # physics step in the simulator, not here.
+    if 'wkt_area_sq_meters' in places.columns:
+        _area_series = pd.to_numeric(places['wkt_area_sq_meters'], errors='coerce')
+        _area_series = _area_series.where(_area_series > 0)
+    else:
+        _area_series = pd.Series([float('nan')] * len(places), index=places.index)
+    _global_med_area = _area_series.median()
+    if pd.isna(_global_med_area):
+        _global_med_area = 650.0
+    _cat_med_area = _area_series.groupby(places['top_category']).median().dropna().to_dict()
+
     for i, row in places.iterrows():
+        _area = _area_series.loc[i]
+        if pd.isna(_area):
+            _area = _cat_med_area.get(row['top_category'], _global_med_area)
         output['places'][str(i)] = {
             'placekey': row['placekey'],
             'label': row['location_name'],
@@ -743,7 +763,8 @@ def convert_data(df, cz_data, shared_data=None):
             'top_category': 'None' if pd.isna(row['top_category']) else row['top_category'],
             'street_address': _clean_optional_text(row.get('street_address')),
             'postal_code': row['postal_code'],
-            'footprint': _coerce_footprint(row.get('polygon_wkt'))
+            'footprint': _coerce_footprint(row.get('polygon_wkt')),
+            'area': float(_area),
         }
 
     return output


### PR DESCRIPTION
## What
Carry SafeGraph `WKT_AREA_SQ_METERS` through to papdata as `places[*].area` (m²), so the simulator can scale Wells-Riley ventilation by a facility's physical floor area.

- `patterns_loader`: add `wkt_area_sq_meters` to the loaded columns and `for_popgen_places`.
- `popgen`: emit `places[*]['area']`, with per-category-median → global-median fallback for POIs missing/zero on the field.

## Why
Data half of **area-aware ventilation** (companion: **Delineo-Disease-Modeling/Simulation#16**, which consumes this `area` field). Today the simulator uses a fixed ventilation `Q` for every facility, so transmission ignores venue size; this emits the area needed to fix that.

## Safety
Inert on its own — nothing reads `area` until the Simulation `area_aware_ventilation` flag is enabled. Coverage in the OK extract: 90% of POIs have `WKT_AREA_SQ_METERS`, 100% have a polygon; the median fallback covers the remainder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
