### PR TITLE
popgen: fix relatives-weighting precedence bug + harden census path

### DIFF
--- a/server/popgen.py
+++ b/server/popgen.py
@@ -431,6 +431,28 @@ class SyntheticPopulationGenerator:
             'num_nonrelatives': has_nonrelatives
         }
     
+    @staticmethod
+    def _relative_type_weights(county_data) -> List[float]:
+        """Sampling weights for a household ``relative``'s type.
+
+        Returns weights aligned to ``['parent', 'sibling', 'grandchild',
+        'other_relative']``. The ``parent`` bucket combines parents and
+        parents-in-law. Weights are raw Census relative counts; ``random.choices``
+        normalizes them internally, so they need not sum to 1.
+
+        Note: this previously had an operator-precedence bug
+        (``parent + parent_in_law / total``) that added the raw ``parent`` count
+        (hundreds–thousands) unnormalized while the other buckets were fractions
+        in ``[0, 1]`` — so the parent bucket won almost every draw and siblings,
+        grandchildren and other relatives were effectively never sampled.
+        """
+        return [
+            county_data["parent"] + county_data["parent-in-law"],  # parent (incl. in-law)
+            county_data["brother_or_sister"],                      # sibling
+            county_data["grandchild"],                             # grandchild
+            county_data["other_relative"],                         # other_relative
+        ]
+
     def generate_household(self, county_data, county_code: str, cbg: str) -> List[Person]:
         """Generate all members of a single household."""
         household_id = self.next_household_id
@@ -504,16 +526,13 @@ class SyntheticPopulationGenerator:
         for _ in range(household_composition['num_relatives']):
             relative_gender = 'M' if random.random() < 0.5 else 'F'
             
-            # Decide which type of relative
-            # TODO: The son-in-law and daughter-in-law categories imply adult children in the home
-                # Revise this to better reflect the actual distribution of relatives
-            tot_other_relatives = county_data["brother_or_sister"] + county_data["parent"] + county_data["parent-in-law"] + county_data["son-in-law or daughter-in-law"] + county_data["other_relative"]
+            # Decide which type of relative.
+            # TODO: The son-in-law and daughter-in-law categories imply adult children
+            # in the home; revise this to better reflect the actual distribution of
+            # relatives (they are currently folded into none of the four buckets).
             relative_type = random.choices(
                 ['parent', 'sibling', 'grandchild', 'other_relative'],
-                weights=[county_data["parent"]+county_data["parent-in-law"]/tot_other_relatives # parent
-                        , county_data["brother_or_sister"]/tot_other_relatives # sibling
-                        , county_data["grandchild"]/tot_other_relatives # grandchild
-                        , county_data["other_relative"]/tot_other_relatives] # other_relative
+                weights=self._relative_type_weights(county_data),
             )[0]
             
             relative = Person(

--- a/server/popgen.py
+++ b/server/popgen.py
@@ -30,16 +30,22 @@ from patterns import _catchment_fraction, _median_fj_fallback
 # docs/MOVEMENT_MODEL_REDESIGN.md §10.
 CATCHMENT_FJ_FLOOR = 0.02
 
+# Census API key. The committed literal is a free, rate-limited Census key that
+# also lives in git history; prefer setting the CENSUS_API_KEY env var and rotate
+# the literal out when convenient.
+CENSUS_API_KEY_DEFAULT = "b1cdc56f4855e77fe024c8b2dfa187b7985cbd89"
+
 
 class CensusDataPuller:
-    def __init__(self, api_key: str = "b1cdc56f4855e77fe024c8b2dfa187b7985cbd89"):
+    def __init__(self, api_key: Optional[str] = None):
         """
         Initialize the CensusDataPuller with the Census API key.
-        
+
         Args:
-            api_key: Census API key. Defaults to the one in your original code.
+            api_key: Census API key. If omitted, falls back to the CENSUS_API_KEY
+                environment variable, then to CENSUS_API_KEY_DEFAULT.
         """
-        self.api_key = api_key
+        self.api_key = api_key or os.environ.get("CENSUS_API_KEY") or CENSUS_API_KEY_DEFAULT
         self.detailed_base_url = "https://api.census.gov/data/2023/acs/acs1"
         self.profile_base_url = "https://api.census.gov/data/2023/acs/acs5/profile"
         
@@ -295,8 +301,12 @@ class CensusDataPuller:
             return relevant_data
             
         except Exception as e:
-            print(f"Error: {e}")
-            return {}
+            # Fail loud: gen_pop is the only caller, and an empty census dict
+            # silently produces a degenerate population (wrong/zero households)
+            # downstream. Surface the failure instead of returning {} — matches the
+            # fail-loud posture in patterns.py.
+            print(f"ERROR: Census data fetch failed: {e}")
+            raise
 
 @dataclass
 
@@ -864,8 +874,10 @@ def gen_pop(cz_data, gdf=None, shared_data=None):
         print("\nPopulation Validation:")
         for key, value in validation_results.items():
             print(f"{key}: {value}")
-    except:
-        print("\nERROR: COULD NOT VALIDATE POPULATION\n")
+    except Exception as e:
+        # Validation is diagnostic (prints stats), so don't make it fatal — but
+        # surface the real error instead of swallowing it under a bare except.
+        print(f"\nERROR: COULD NOT VALIDATE POPULATION: {e}\n")
 
     # Save the population to CSV
     population = generator.save_population(population)
@@ -879,5 +891,6 @@ if __name__ == '__main__':
         
         with open(r'./output/papdata.json', 'w') as f:
             json.dump(papdata, f)
-    except:
-        print('ERROR: Could not generated papdata.json')
+    except Exception as e:
+        print(f'ERROR: could not generate papdata.json: {e}')
+        raise

--- a/tests/algorithms_server/test_popgen_census_robustness.py
+++ b/tests/algorithms_server/test_popgen_census_robustness.py
@@ -1,0 +1,50 @@
+"""CensusDataPuller hardening: configurable API key + fail-loud census fetch.
+
+Guards two popgen changes:
+  - the Census API key is no longer a hardcoded constructor default; it resolves
+    explicit arg -> CENSUS_API_KEY env var -> CENSUS_API_KEY_DEFAULT.
+  - pull_counties_census_data re-raises on fetch failure instead of silently
+    returning {}, which previously fed a degenerate population into gen_pop.
+"""
+import sys
+from pathlib import Path
+
+# Mirror test_popgen_catchment_fj: force this checkout's server/ to the front and
+# evict any popgen the shared conftest cached from a different checkout.
+_SERVER = Path(__file__).resolve().parents[2] / "server"
+if str(_SERVER) not in sys.path:
+    sys.path.insert(0, str(_SERVER))
+for _m in ("patterns", "patterns_loader", "popgen"):
+    sys.modules.pop(_m, None)
+
+import pytest  # noqa: E402
+
+from popgen import CENSUS_API_KEY_DEFAULT, CensusDataPuller  # noqa: E402
+
+
+def test_api_key_defaults_to_module_constant(monkeypatch):
+    monkeypatch.delenv("CENSUS_API_KEY", raising=False)
+    assert CensusDataPuller().api_key == CENSUS_API_KEY_DEFAULT
+
+
+def test_api_key_reads_env_var(monkeypatch):
+    monkeypatch.setenv("CENSUS_API_KEY", "env-key-123")
+    assert CensusDataPuller().api_key == "env-key-123"
+
+
+def test_explicit_api_key_wins_over_env(monkeypatch):
+    monkeypatch.setenv("CENSUS_API_KEY", "env-key-123")
+    assert CensusDataPuller(api_key="explicit-key").api_key == "explicit-key"
+
+
+def test_pull_counties_reraises_on_fetch_failure(monkeypatch):
+    puller = CensusDataPuller(api_key="x")
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("census API down")
+
+    monkeypatch.setattr(puller, "fetch_census_data", boom)
+    # Must propagate, not return {} — an empty census dict silently degenerates
+    # the population downstream in gen_pop.
+    with pytest.raises(RuntimeError, match="census API down"):
+        puller.pull_counties_census_data("40", ["001"], None)

--- a/tests/algorithms_server/test_popgen_relative_weights.py
+++ b/tests/algorithms_server/test_popgen_relative_weights.py
@@ -1,0 +1,65 @@
+"""Relative-type sampling weights in popgen (SyntheticPopulationGenerator).
+
+Guards a former operator-precedence bug in ``generate_household`` where the
+``parent`` weight was ``parent + parent_in_law / total`` instead of
+``(parent + parent_in_law)``. Because ``random.choices`` takes raw (unnormalized)
+weights, the un-divided ``parent`` count (hundreds–thousands) dwarfed the other
+buckets (fractions < 1), so siblings, grandchildren and other relatives were
+almost never drawn. The fix combines parent + parent-in-law into one bucket and
+lets ``random.choices`` normalize the raw counts.
+"""
+import sys
+from pathlib import Path
+
+# conftest.py hard-codes (and chdirs to) the MAIN Algorithms checkout, so force
+# the local checkout's server/ to the front of the path and evict any popgen the
+# shared conftest cached from a different checkout (mirrors test_popgen_catchment_fj).
+_SERVER = Path(__file__).resolve().parents[2] / "server"
+if str(_SERVER) not in sys.path:
+    sys.path.insert(0, str(_SERVER))
+for _m in ("patterns", "patterns_loader", "popgen"):
+    sys.modules.pop(_m, None)
+
+import random  # noqa: E402
+
+from popgen import SyntheticPopulationGenerator  # noqa: E402
+
+# A county where 'parent' is a minority of relatives and siblings/other-relatives
+# dominate. Under the precedence bug the parent bucket would still win ~every draw.
+COUNTY = {
+    "parent": 10,
+    "parent-in-law": 5,
+    "brother_or_sister": 30,
+    "grandchild": 20,
+    "other_relative": 35,
+    "son-in-law or daughter-in-law": 7,
+}
+CHOICES = ["parent", "sibling", "grandchild", "other_relative"]
+
+
+def test_parent_bucket_combines_in_law_counts():
+    # parent bucket = parent + parent-in-law = 15; others are their raw counts.
+    assert SyntheticPopulationGenerator._relative_type_weights(COUNTY) == [15, 30, 20, 35]
+
+
+def test_weights_are_proportional_not_a_dominating_parent():
+    w = SyntheticPopulationGenerator._relative_type_weights(COUNTY)
+    # Regression guard: the parent bucket must be a normal proportional weight,
+    # never the near-certain winner the precedence bug produced.
+    assert w[0] < w[1]                                   # parents (15) < siblings (30)
+    assert w[0] < w[3]                                   # parents (15) < other (35)
+    assert max(range(len(w)), key=lambda i: w[i]) == 3   # 'other_relative' most likely
+
+
+def test_sampling_distribution_reflects_census_counts():
+    random.seed(1234)
+    w = SyntheticPopulationGenerator._relative_type_weights(COUNTY)
+    total = float(sum(w))
+    n = 40_000
+    draws = random.choices(CHOICES, weights=w, k=n)
+    freq = {c: draws.count(c) / n for c in CHOICES}
+    expected = {c: wi / total for c, wi in zip(CHOICES, w)}
+    for c in CHOICES:
+        assert abs(freq[c] - expected[c]) < 0.02, (c, freq[c], expected[c])
+    # The bug's signature was parent dominating (~>0.9). It should now sit near 0.15.
+    assert freq["parent"] < 0.25


### PR DESCRIPTION
Two popgen fixes surfaced by a read-only refactor assessment of `main`. Additive/surgical; **full Algorithms suite 52 passed** (45 original + 7 new).

## 1. Relatives-type weighting precedence bug (correctness)
`generate_household` sampled a relative's type with
`weights=[parent + parent-in-law/total, sibling/total, grandchild/total, other_relative/total]`.
Operator precedence binds the division tighter than the addition, so only `parent-in-law` was normalized — the raw `parent` count (hundreds–thousands) was added unnormalized while the other three buckets were fractions in `[0, 1]`. `random.choices` accepts unnormalized weights, so it ran silently while the **parent bucket won ~every draw** — siblings, grandchildren, and other relatives were effectively never generated, skewing the synthetic population's relative-type distribution.

Fix: extracted a pure, unit-testable `SyntheticPopulationGenerator._relative_type_weights`; the `parent` bucket is now `(parent + parent-in-law)` as raw counts (the per-bucket `/total` was a no-op for `random.choices` and is dropped). The son-in-law/daughter-in-law category is unchanged — it was never one of the four buckets (documented TODO).

## 2. Census path hardening
- **API key** is no longer a hardcoded constructor default; it resolves `explicit arg -> CENSUS_API_KEY env var -> CENSUS_API_KEY_DEFAULT`. The literal is a free, rate-limited key already in git history — kept as last-resort fallback so the offline path keeps working, and flagged for rotation.
- **`pull_counties_census_data` now fails loud** (re-raises) instead of catching broadly and returning `{}`. Its only caller (`gen_pop`) turned that empty dict into a degenerate population presented as success. ⚠️ **Behavior change:** on the live CZ-generation path a Census API failure now returns 500 instead of silently producing bad data.
- Two bare `except:` blocks narrowed to `except Exception` with the real error surfaced (validation stays non-fatal; `__main__` re-raises). Fixed the "Could not generated" typo.

## Tests
- `test_popgen_relative_weights` (3): parent bucket combines in-law counts, weights stay proportional (parent no longer dominates), seeded draw matches census proportions.
- `test_popgen_census_robustness` (4): key resolution precedence; `pull_counties_census_data` propagates a fetch error rather than returning `{}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)